### PR TITLE
Create PLY files that VTK 8.1.2 can load

### DIFF
--- a/FullTextureMapper.py
+++ b/FullTextureMapper.py
@@ -536,7 +536,7 @@ class FullTextureMapper(object):
                 face_str = '{}'.format(np.uint8(len(face)))
                 for vertex_idx in face:
                     face_str += ' {}'.format(np.int32(vertex_idx))
-                face_str += '\n'
+                face_str += ' '     
 
                 texcoord_str = '{}'.format(np.uint8(len(face) * 2))
                 for uv in uv_coords:


### PR DESCRIPTION
VTK 8.1.2 crashes on loading PLY files with newlines within the data for each face.

NOTE - VTK 8.1.2 does not properly handle texture coordinates per face.  So VTK 8.1.2 cannot display the textures as created here.  But with the patch, at least VTK 8.1.2 can load the geometry.

VTK 8.2 should be able to display the textures created here using texture coordinates per face.  But VTK 8.1.2 is the latest available in pypi